### PR TITLE
chore(readme): use picker url for new issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Proposals are written in [issues in this repository](https://github.com/stencil-
 To create a new proposal,
 
 1. Search for existing proposals in [the issues](https://github.com/stencil-community/proposals/issues). The proposal may exist already. If it does, please feel free to add a :+1: reaction to the issue summary, and/or add your thoughts in the form of a comment on the issue.
-1. If it does not exist, [create a new issue](https://github.com/stencil-community/proposals/issues/new) and fill out the template. :sparkles:
+1. If it does not exist, [create a new issue](https://github.com/stencil-community/proposals/issues/new/choose) and fill out the template. :sparkles:


### PR DESCRIPTION
previously, the proper template URL was not being used, this
commit moves us to the new picker URL to guide folks to using
the templates for a new issue/package/etc.